### PR TITLE
Two changes to improve the successrate of BozoCrack

### DIFF
--- a/bozocrack.rb
+++ b/bozocrack.rb
@@ -35,7 +35,17 @@ class BozoCrack
   private
 
   def crack_single_hash(hash)
-    response = Net::HTTP.get URI("http://www.google.com/search?q=#{hash}")
+    if plaintext = crack_single_hash_with_website(hash, "http://www.google.com/search?q=#{hash}")
+      return plaintext
+    end
+    if plaintext = crack_single_hash_with_website(hash, "http://www.google.com/search?q=md5+#{hash}")
+      return plaintext
+    end
+    nil
+  end
+
+  def crack_single_hash_with_website(hash, url)
+    response = Net::HTTP.get URI(url)
     wordlist = response.split(/\s+/)
     if plaintext = dictionary_attack(hash, wordlist)
       return plaintext
@@ -47,6 +57,12 @@ class BozoCrack
     wordlist.each do |word|
       if Digest::MD5.hexdigest(word) == hash.downcase
         return word
+      end
+      sub_wordlist = word.split(/[^a-zA-Z0-9]+/)
+      if (sub_wordlist.size > 1)
+        if plaintext = dictionary_attack(hash, sub_wordlist)
+          return plaintext
+        end
       end
     end
     nil


### PR DESCRIPTION
This commit adds two changes to improve the successrate of BozoCrack:
1. If the old method didn't find the hash, split the Google results on non-alphanumeric characters. This will find the hashes on pages which contain text such as:
   - md5(password) = 5f4dcc3b5aa765d61d8327deb882cf99
   - md5("password") = 5f4dcc3b5aa765d61d8327deb882cf99
   - password:5f4dcc3b5aa765d61d8327deb882cf99
2. If that still didn't find the hash, do another Google search for the hash and the word md5. This helps for hashes that may by luck appear in their hashed form frequently on the web. For instance, compare:
   http://www.google.com/search?q=0e97d6e7124d6cc9623650201236cd52
   and
   http://www.google.com/search?q=md5+0e97d6e7124d6cc9623650201236cd52
   At the time of implementing this change, the first Google results did
   not contain the plaintext for this hash.
